### PR TITLE
Add FactSet Search Answers package bugs metadata

### DIFF
--- a/code/typescript/FactSetSearchAnswers/v1/package.json
+++ b/code/typescript/FactSetSearchAnswers/v1/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/factset/enterprise-sdk.git",
     "directory": "code/typescript/FactSetSearchAnswers/v1"
   },
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary
- add bugs.url metadata for @factset/sdk-factsetsearchanswers

## Verification
- node package manifest assertion
- git diff --check
- npm pack --dry-run --ignore-scripts --json ./code/typescript/FactSetSearchAnswers/v1