### PR TITLE
Add bugs metadata for Analytics Datastore SDK

### DIFF
--- a/code/typescript/AnalyticsDatastore/v1/package.json
+++ b/code/typescript/AnalyticsDatastore/v1/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/factset/enterprise-sdk.git",
     "directory": "code/typescript/AnalyticsDatastore/v1"
   },
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary
- add the package issue tracker to `@factset/sdk-analyticsdatastore`
- keep the metadata aligned with the existing repository and homepage fields

## Verification
- `node -e 'const p=require("./code/typescript/AnalyticsDatastore/v1/package.json"); if(p.name!=="@factset/sdk-analyticsdatastore"||p.version!=="0.24.0"||p.bugs?.url!=="https://github.com/factset/enterprise-sdk/issues") throw new Error(JSON.stringify(p.bugs)); console.log(JSON.stringify({name:p.name,version:p.version,bugs:p.bugs},null,2));'`\n- `git diff --check`\n- `npm pack --dry-run --ignore-scripts --json ./code/typescript/AnalyticsDatastore/v1`