### PR TITLE
Add bugs metadata for Conversational API SDK

### DIFF
--- a/code/typescript/ConversationalAPIPoweredbyFactSetMercury/v1/package.json
+++ b/code/typescript/ConversationalAPIPoweredbyFactSetMercury/v1/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/factset/enterprise-sdk.git",
     "directory": "code/typescript/ConversationalAPIPoweredbyFactSetMercury/v1"
   },
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary
- add the missing bugs metadata for @factset/sdk-conversationalapipoweredbyfactsetmercury
- point issue reporting to the FactSet enterprise SDK issue tracker

## Verification
- node manifest assertion for package name, version, and bugs.url
- git diff --check
- npm pack --dry-run --ignore-scripts --json ./code/typescript/ConversationalAPIPoweredbyFactSetMercury/v1