### PR TITLE
Add bugs metadata for CallStreet Events SDK

### DIFF
--- a/code/typescript/DocumentsDistributorCallStreetEvents/v1/package.json
+++ b/code/typescript/DocumentsDistributorCallStreetEvents/v1/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/factset/enterprise-sdk.git",
     "directory": "code/typescript/DocumentsDistributorCallStreetEvents/v1"
   },
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary
- add the missing bugs metadata for @factset/sdk-documentsdistributorcallstreetevents
- point issue reporting to the FactSet enterprise SDK issue tracker

## Verification
- node manifest assertion for package name, version, and bugs.url
- git diff --check
- npm pack --dry-run --ignore-scripts --json ./code/typescript/DocumentsDistributorCallStreetEvents/v1