### PR TITLE
Add bugs metadata for Foreign Exchange Rate SDK

### DIFF
--- a/code/typescript/ForeignExchangeRate/v1/package.json
+++ b/code/typescript/ForeignExchangeRate/v1/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/factset/enterprise-sdk.git",
     "directory": "code/typescript/ForeignExchangeRate/v1"
   },
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary
- add npm `bugs.url` metadata for `@factset/sdk-foreignexchangerate`
- point issue reporting to the existing FactSet enterprise SDK issue tracker

## Verification
- parsed `code/typescript/ForeignExchangeRate/v1/package.json` and confirmed name/version/repository/bugs metadata
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json ./code/typescript/ForeignExchangeRate/v1`