### PR TITLE
Add bugs metadata for Funds API Digital Portals SDK

### DIFF
--- a/code/typescript/FundsAPIforDigitalPortals/v2/package.json
+++ b/code/typescript/FundsAPIforDigitalPortals/v2/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/factset/enterprise-sdk.git",
     "directory": "code/typescript/FundsAPIforDigitalPortals/v2"
   },
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "engines": {
     "node": ">=14"
   },


### PR DESCRIPTION
## Summary
- add npm `bugs.url` metadata for `@factset/sdk-fundsapifordigitalportals`
- point issue reporting to the existing FactSet enterprise SDK issue tracker

## Verification
- parsed `code/typescript/FundsAPIforDigitalPortals/v2/package.json` and confirmed name/version/repository/bugs metadata
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json ./code/typescript/FundsAPIforDigitalPortals/v2`