### PR TITLE
Add bugs metadata for IRN Configuration SDK

### DIFF
--- a/code/typescript/IRNConfiguration/v1/package.json
+++ b/code/typescript/IRNConfiguration/v1/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/factset/enterprise-sdk.git",
     "directory": "code/typescript/IRNConfiguration/v1"
   },
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary
- add `bugs.url` metadata for the `@factset/sdk-irnconfiguration` package
- point bug reports to the existing FactSet enterprise SDK issue tracker

## Validation
- `node -e 'const p=require("./code/typescript/IRNConfiguration/v1/package.json"); if(p.name!=="@factset/sdk-irnconfiguration") throw new Error(p.name); if(p.version!=="3.0.0") throw new Error(p.version); if(p.repository?.directory!=="code/typescript/IRNConfiguration/v1") throw new Error(p.repository?.directory); if(p.bugs?.url!=="https://github.com/factset/enterprise-sdk/issues") throw new Error(p.bugs?.url); console.log("manifest ok")'`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json ./code/typescript/IRNConfiguration/v1`
