### PR TITLE
Add bugs metadata for IRN Contacts SDK

### DIFF
--- a/code/typescript/IRNContacts/v1/package.json
+++ b/code/typescript/IRNContacts/v1/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/factset/enterprise-sdk.git",
     "directory": "code/typescript/IRNContacts/v1"
   },
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary
- add `bugs.url` metadata for the `@factset/sdk-irncontacts` package
- point bug reports to the existing FactSet enterprise SDK issue tracker

## Validation
- `node -e 'const p=require("./code/typescript/IRNContacts/v1/package.json"); if(p.name!=="@factset/sdk-irncontacts") throw new Error(p.name); if(p.version!=="2.0.1") throw new Error(p.version); if(p.repository?.directory!=="code/typescript/IRNContacts/v1") throw new Error(p.repository?.directory); if(p.bugs?.url!=="https://github.com/factset/enterprise-sdk/issues") throw new Error(p.bugs?.url); console.log("manifest ok")'`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json ./code/typescript/IRNContacts/v1`
