### PR TITLE
Add package metadata for Intraday Tick History SDK

### DIFF
--- a/code/typescript/IntradayTickHistory/v1/package.json
+++ b/code/typescript/IntradayTickHistory/v1/package.json
@@ -11,6 +11,15 @@
     "prepare": "npm run build",
     "test": "mocha --require @babel/register --recursive"
   },
+  "homepage": "https://developer.factset.com/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/factset/enterprise-sdk.git",
+    "directory": "code/typescript/IntradayTickHistory/v1"
+  },
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "engines": {
     "node": ">=12"
   },


### PR DESCRIPTION
## Summary
- add `homepage`, `repository`, and `bugs.url` metadata for the `@factset/sdk-intradaytickhistory` package
- point bug reports to the existing FactSet enterprise SDK issue tracker

## Validation
- `node -e 'const p=require("./code/typescript/IntradayTickHistory/v1/package.json"); if(p.name!=="@factset/sdk-intradaytickhistory") throw new Error(p.name); if(p.version!=="0.20.0") throw new Error(p.version); if(p.homepage!=="https://developer.factset.com/") throw new Error(p.homepage); if(p.repository?.directory!=="code/typescript/IntradayTickHistory/v1") throw new Error(p.repository?.directory); if(p.bugs?.url!=="https://github.com/factset/enterprise-sdk/issues") throw new Error(p.bugs?.url); console.log("manifest ok")'`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json ./code/typescript/IntradayTickHistory/v1`
