### PR TITLE
Add bugs metadata for News API for Digital Portals SDK

### DIFF
--- a/code/typescript/NewsAPIforDigitalPortals/v2/package.json
+++ b/code/typescript/NewsAPIforDigitalPortals/v2/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/factset/enterprise-sdk.git",
     "directory": "code/typescript/NewsAPIforDigitalPortals/v2"
   },
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "engines": {
     "node": ">=14"
   },


### PR DESCRIPTION
## Summary
- add bugs.url metadata for @factset/sdk-newsapifordigitalportals

## Validation
- node -e manifest check for name/version/repository.directory/bugs.url
- git diff --check
- npm pack --dry-run --ignore-scripts --json ./code/typescript/NewsAPIforDigitalPortals/v2