### PR TITLE
Add bugs metadata for OPEN:OPTIMIZER SDK

### DIFF
--- a/code/typescript/OPENOPTIMIZER/v1/package.json
+++ b/code/typescript/OPENOPTIMIZER/v1/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/factset/enterprise-sdk.git",
     "directory": "code/typescript/OPENOPTIMIZER/v1"
   },
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary
- add bugs.url metadata for @factset/sdk-openoptimizer

## Validation
- node -e manifest check for name/version/repository.directory/bugs.url
- git diff --check
- npm pack --dry-run --ignore-scripts --json ./code/typescript/OPENOPTIMIZER/v1