### PR TITLE
Add package metadata for Procure to Pay SCIM SDK

### DIFF
--- a/code/typescript/ProcuretoPaySCIM/v1/package.json
+++ b/code/typescript/ProcuretoPaySCIM/v1/package.json
@@ -11,6 +11,15 @@
     "prepare": "npm run build",
     "test": "mocha --require @babel/register --recursive"
   },
+  "homepage": "https://developer.factset.com/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/factset/enterprise-sdk.git",
+    "directory": "code/typescript/ProcuretoPaySCIM/v1"
+  },
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "engines": {
     "node": ">=12"
   },


### PR DESCRIPTION
## Summary
- add homepage, repository, and bugs.url metadata for @factset/sdk-procuretopayscim

## Validation
- node -e manifest check for name/version/homepage/repository.directory/bugs.url
- git diff --check
- npm pack --dry-run --ignore-scripts --json ./code/typescript/ProcuretoPaySCIM/v1