### PR TITLE
Add bugs metadata for Real-Time Time Series SDK

### DIFF
--- a/code/typescript/RealTimeTimeSeries/v4/package.json
+++ b/code/typescript/RealTimeTimeSeries/v4/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/factset/enterprise-sdk.git",
     "directory": "code/typescript/RealTimeTimeSeries/v4"
   },
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary
- add bugs.url metadata for @factset/sdk-realtimetimeseries

## Validation
- node -e manifest check for name/version/repository.directory/bugs.url
- git diff --check
- npm pack --dry-run --ignore-scripts --json ./code/typescript/RealTimeTimeSeries/v4