### PR TITLE
Add bugs metadata for S&P Global Fixed Income SDK

### DIFF
--- a/code/typescript/SPGlobalFixedIncomeEvaluatedPricesandAnalytics/v1/package.json
+++ b/code/typescript/SPGlobalFixedIncomeEvaluatedPricesandAnalytics/v1/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/factset/enterprise-sdk.git",
     "directory": "code/typescript/SPGlobalFixedIncomeEvaluatedPricesandAnalytics/v1"
   },
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary
- add bugs.url metadata for @factset/sdk-spglobalfixedincomeevaluatedpricesandanalytics

## Validation
- node -e manifest check for name/version/repository.directory/bugs.url
- git diff --check
- npm pack --dry-run --ignore-scripts --json ./code/typescript/SPGlobalFixedIncomeEvaluatedPricesandAnalytics/v1