### PR TITLE
Add bugs metadata for Barra Portfolio Optimizer SDK

### DIFF
--- a/code/typescript/BarraPortfolioOptimizer/v3/package.json
+++ b/code/typescript/BarraPortfolioOptimizer/v3/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/factset/enterprise-sdk.git",
     "directory": "code/typescript/BarraPortfolioOptimizer/v3"
   },
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary
- add bugs.url metadata for @factset/sdk-barraportfoliooptimizer
- point npm consumers to the FactSet enterprise-sdk issue tracker

## Validation
- node manifest check
- git diff --check
- npm pack --dry-run --ignore-scripts --json ./code/typescript/BarraPortfolioOptimizer/v3