### PR TITLE
Add bugs metadata for BEAST SDK

### DIFF
--- a/code/typescript/BestExecutionAnalyticsforSmarterTradingBEAST/v4/package.json
+++ b/code/typescript/BestExecutionAnalyticsforSmarterTradingBEAST/v4/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/factset/enterprise-sdk.git",
     "directory": "code/typescript/BestExecutionAnalyticsforSmarterTradingBEAST/v4"
   },
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary
- add bugs.url metadata for @factset/sdk-bestexecutionanalyticsforsmartertradingbeast
- point npm consumers to the FactSet enterprise-sdk issue tracker

## Validation
- node manifest check
- git diff --check
- npm pack --dry-run --ignore-scripts --json ./code/typescript/BestExecutionAnalyticsforSmarterTradingBEAST/v4