### PR TITLE
Add bugs metadata for FactSet Debt Capital Structure SDK

### DIFF
--- a/code/typescript/FactSetDebtCapitalStructure/v1/package.json
+++ b/code/typescript/FactSetDebtCapitalStructure/v1/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/factset/enterprise-sdk.git",
     "directory": "code/typescript/FactSetDebtCapitalStructure/v1"
   },
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary
- add bugs.url metadata for @factset/sdk-factsetdebtcapitalstructure
- point npm consumers to the FactSet enterprise-sdk issue tracker

## Validation
- node manifest check
- git diff --check
- npm pack --dry-run --ignore-scripts --json ./code/typescript/FactSetDebtCapitalStructure/v1