### PR TITLE
Add npm bugs metadata for TypeScript SDKs

### DIFF
--- a/code/typescript/FactSetEstimates/v2/package.json
+++ b/code/typescript/FactSetEstimates/v2/package.json
@@ -12,6 +12,9 @@
     "test": "mocha --require @babel/register --recursive"
   },
   "homepage": "https://developer.factset.com/",
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/factset/enterprise-sdk.git",

--- a/code/typescript/FactSetFundamentals/v2/package.json
+++ b/code/typescript/FactSetFundamentals/v2/package.json
@@ -12,6 +12,9 @@
     "test": "mocha --require @babel/register --recursive"
   },
   "homepage": "https://developer.factset.com/",
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/factset/enterprise-sdk.git",

--- a/code/typescript/FactSetFunds/v3/package.json
+++ b/code/typescript/FactSetFunds/v3/package.json
@@ -12,6 +12,9 @@
     "test": "mocha --require @babel/register --recursive"
   },
   "homepage": "https://developer.factset.com/",
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/factset/enterprise-sdk.git",

--- a/code/typescript/FactSetGlobalPrices/v1/package.json
+++ b/code/typescript/FactSetGlobalPrices/v1/package.json
@@ -12,6 +12,9 @@
     "test": "mocha --require @babel/register --recursive"
   },
   "homepage": "https://developer.factset.com/",
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/factset/enterprise-sdk.git",

--- a/code/typescript/FactSetNER/v2/package.json
+++ b/code/typescript/FactSetNER/v2/package.json
@@ -12,6 +12,9 @@
     "test": "mocha --require @babel/register --recursive"
   },
   "homepage": "https://developer.factset.com/",
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/factset/enterprise-sdk.git",

--- a/code/typescript/FactSetOwnership/v1/package.json
+++ b/code/typescript/FactSetOwnership/v1/package.json
@@ -12,6 +12,9 @@
     "test": "mocha --require @babel/register --recursive"
   },
   "homepage": "https://developer.factset.com/",
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/factset/enterprise-sdk.git",

--- a/code/typescript/FactSetPortfolioOptimizer/v3/package.json
+++ b/code/typescript/FactSetPortfolioOptimizer/v3/package.json
@@ -12,6 +12,9 @@
     "test": "mocha --require @babel/register --recursive"
   },
   "homepage": "https://developer.factset.com/",
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/factset/enterprise-sdk.git",

--- a/code/typescript/FactSetPrices/v1/package.json
+++ b/code/typescript/FactSetPrices/v1/package.json
@@ -12,6 +12,9 @@
     "test": "mocha --require @babel/register --recursive"
   },
   "homepage": "https://developer.factset.com/",
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/factset/enterprise-sdk.git",

--- a/code/typescript/FactSetTickHistory/v2/package.json
+++ b/code/typescript/FactSetTickHistory/v2/package.json
@@ -12,6 +12,9 @@
     "test": "mocha --require @babel/register --recursive"
   },
   "homepage": "https://developer.factset.com/",
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/factset/enterprise-sdk.git",


### PR DESCRIPTION
## Summary

Adds npm `bugs.url` metadata to nine TypeScript SDK package manifests that already have repository and homepage metadata.

Updated packages:

- `@factset/sdk-factsetfunds@0.40.1`
- `@factset/sdk-factsetglobalprices@3.6.0`
- `@factset/sdk-factsetprices@2.0.1`
- `@factset/sdk-factsetestimates@4.3.1`
- `@factset/sdk-factsetfundamentals@4.1.0`
- `@factset/sdk-factsetownership@2.4.1`
- `@factset/sdk-factsettickhistory@1.3.0`
- `@factset/sdk-factsetportfoliooptimizer@0.22.1`
- `@factset/sdk-factsetner@0.22.1`

## Why

These package manifests currently publish repository and homepage metadata, but omit `bugs.url`. Adding the issue tracker URL gives npm and downstream tooling a machine-readable support target without changing runtime code.

## Validation

- Parsed each changed `package.json` before and after the update.
- Verified each changed manifest now contains `"bugs": { "url": "https://github.com/factset/enterprise-sdk/issues" }`.
- No runtime files were changed.

Related to charles-openclaw/charles-microbounties#1180, #1181, #1182, #1183, #1184, #1185, #1186, #1187, and #1188.