### PR TITLE
chore(publish): starter publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      apiIncludeList:
+        description: 'Limit publishing to this list of API(s) and optional versions, uses the `normalizedName` like "PA Engine API" -> "PAEngine". Example: PAEngine:1,SPAREngine:3,Symbology'
+        required: true
+      languageToPublish:
+        description: "Language to publish"
+        required: true
+        type: choice
+        options:
+          - "all"
+          - "dotnet"
+          - "java"
+          - "python"
+          - "typescript"
+
+jobs:
+  publish-typescript:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.languageToPublish == 'all' || github.event.inputs.languageToPublish == 'typescript' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: "yarn"


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to support publishing packages, with configurable options for selecting APIs and target languages. The workflow introduces a manual trigger and a job for publishing TypeScript packages.

**New workflow for package publishing:**

* Added `.github/workflows/publish.yml` to define a new workflow named "Publish Packages" that can be triggered manually with customizable inputs.
* Introduced `apiIncludeList` and `languageToPublish` as required inputs, allowing users to specify which APIs and languages to publish.
* Implemented a `publish-typescript` job that runs on Ubuntu, checks out the repository, installs Node.js, and sets up a Yarn cache, conditionally running when the selected language is "all" or "typescript".