### PR TITLE
chore(publish): implement batch publishing for TypeScript packages

### DIFF
--- a/.github/scripts/publish-batch.sh
+++ b/.github/scripts/publish-batch.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+publish_script="$GITHUB_WORKSPACE/.github/scripts/publish-${LANGUAGE}.sh"
+if [ ! -f "$publish_script" ]; then
+  echo "::error::No publish script found at '$publish_script'"
+  exit 1
+fi
+
+read -ra pkgs <<< "$PKG_PATHS"
+if [ "${#pkgs[@]}" -eq 0 ]; then
+  echo "::error::PKG_PATHS is empty"
+  exit 1
+fi
+
+echo "Batch ${BATCH_ID}: publishing ${#pkgs[@]} ${LANGUAGE} package(s)"
+printf '  %s\n' "${pkgs[@]}"
+
+published=()
+failed=()
+for pkg in "${pkgs[@]}"; do
+  echo "::group::Publishing ${pkg}"
+  if (cd "$GITHUB_WORKSPACE/$pkg" && PKG_PATH="$pkg" bash "$publish_script"); then
+    published+=("$pkg")
+  else
+    echo "::error::Failed to publish '${pkg}'"
+    failed+=("$pkg")
+  fi
+  echo "::endgroup::"
+done
+
+{
+  echo "### Batch ${BATCH_ID} — ${LANGUAGE} (dry run: ${DRY_RUN})"
+  echo
+  echo "| Package | Result |"
+  echo "| --- | --- |"
+  for pkg in "${published[@]}"; do echo "| \`${pkg}\` | published |"; done
+  for pkg in "${failed[@]}"; do echo "| \`${pkg}\` | **failed** |"; done
+} >> "$GITHUB_STEP_SUMMARY"
+
+echo "Batch ${BATCH_ID}: ${#published[@]} published, ${#failed[@]} failed"
+if [ "${#failed[@]}" -ne 0 ]; then
+  echo "::error::Batch ${BATCH_ID} had ${#failed[@]} failure(s): ${failed[*]}"
+  exit 1
+fi

--- a/.github/scripts/publish-batch.sh
+++ b/.github/scripts/publish-batch.sh
@@ -16,30 +16,57 @@ fi
 echo "Batch ${BATCH_ID}: publishing ${#pkgs[@]} ${LANGUAGE} package(s)"
 printf '  %s\n' "${pkgs[@]}"
 
+status_file=$(mktemp)
+trap 'rm -f "$status_file"' EXIT
+
 published=()
+skipped=()
 failed=()
 for pkg in "${pkgs[@]}"; do
   echo "::group::Publishing ${pkg}"
-  if (cd "$GITHUB_WORKSPACE/$pkg" && PKG_PATH="$pkg" bash "$publish_script"); then
-    published+=("$pkg")
+  : > "$status_file"
+  if (cd "$GITHUB_WORKSPACE/$pkg" && PKG_PATH="$pkg" PKG_STATUS_FILE="$status_file" bash "$publish_script"); then
+    # The language script reports "<status>|<detail>"; assume published if it
+    # reported nothing, so a script that predates this contract still works.
+    reported="$(cat "$status_file")"
+    status="${reported%%|*}"
+    if [ "$reported" = "$status" ]; then
+      detail=""
+    else
+      detail="${reported#*|}"
+    fi
+    case "$status" in
+      skipped) skipped+=("${pkg}|${detail}") ;;
+      *) published+=("${pkg}|${detail}") ;;
+    esac
   else
     echo "::error::Failed to publish '${pkg}'"
-    failed+=("$pkg")
+    failed+=("${pkg}|")
   fi
   echo "::endgroup::"
 done
 
+row() {
+  local entry="$1" result="$2" pkg detail
+  pkg="${entry%%|*}"
+  detail="${entry#*|}"
+  echo "| \`${pkg}\` | ${detail:-–} | ${result} |"
+}
+
 {
   echo "### Batch ${BATCH_ID} — ${LANGUAGE} (dry run: ${DRY_RUN})"
   echo
-  echo "| Package | Result |"
-  echo "| --- | --- |"
-  for pkg in "${published[@]}"; do echo "| \`${pkg}\` | published |"; done
-  for pkg in "${failed[@]}"; do echo "| \`${pkg}\` | **failed** |"; done
+  echo "| Package | Version | Result |"
+  echo "| --- | --- | --- |"
+  for entry in "${published[@]}"; do row "$entry" "published"; done
+  for entry in "${skipped[@]}"; do row "$entry" "skipped (already published)"; done
+  for entry in "${failed[@]}"; do row "$entry" "**failed**"; done
 } >> "$GITHUB_STEP_SUMMARY"
 
-echo "Batch ${BATCH_ID}: ${#published[@]} published, ${#failed[@]} failed"
+echo "Batch ${BATCH_ID}: ${#published[@]} published, ${#skipped[@]} skipped, ${#failed[@]} failed"
 if [ "${#failed[@]}" -ne 0 ]; then
-  echo "::error::Batch ${BATCH_ID} had ${#failed[@]} failure(s): ${failed[*]}"
+  failed_pkgs=()
+  for entry in "${failed[@]}"; do failed_pkgs+=("${entry%%|*}"); done
+  echo "::error::Batch ${BATCH_ID} had ${#failed[@]} failure(s): ${failed_pkgs[*]}"
   exit 1
 fi

--- a/.github/scripts/publish-typescript.sh
+++ b/.github/scripts/publish-typescript.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+pkg_path="${PKG_PATH:-$PWD}"
+pkg_name=$(jq -r '.name' package.json)
+pkg_version=$(jq -r '.version' package.json)
+
+echo "Publishing ${pkg_name}@${pkg_version} from ${pkg_path} (dry run: ${DRY_RUN})"
+
 publish_args=(--access public)
 if [ "$DRY_RUN" = "true" ]; then
   publish_args+=(--dry-run)

--- a/.github/scripts/publish-typescript.sh
+++ b/.github/scripts/publish-typescript.sh
@@ -4,8 +4,28 @@ set -euo pipefail
 pkg_path="${PKG_PATH:-$PWD}"
 pkg_name=$(jq -r '.name' package.json)
 pkg_version=$(jq -r '.version' package.json)
+registry="https://registry.npmjs.org"
 
 echo "Publishing ${pkg_name}@${pkg_version} from ${pkg_path} (dry run: ${DRY_RUN})"
+
+# Report the outcome back to publish-batch.sh, which renders the run summary.
+report_status() {
+  if [ -n "${PKG_STATUS_FILE:-}" ]; then
+    printf '%s|%s\n' "$1" "$2" > "$PKG_STATUS_FILE"
+  fi
+}
+
+# `npm view` prints nothing and exits 0 when the package exists but this version
+# does not, and fails with E404 when the package itself is unknown. Either way an
+# empty result means the version has not been published yet. A transient registry
+# error also lands here - publishing then fails on the registry's own duplicate
+# check, so a false negative cannot overwrite an existing version.
+existing=$(npm view "${pkg_name}@${pkg_version}" version --registry "$registry" 2>/dev/null || true)
+if [ -n "$existing" ]; then
+  echo "::notice::${pkg_name}@${pkg_version} is already published - skipping."
+  report_status skipped "${pkg_name}@${pkg_version}"
+  exit 0
+fi
 
 publish_args=(--access public)
 if [ "$DRY_RUN" = "true" ]; then
@@ -20,3 +40,5 @@ yarn set version stable
 yarn install
 yarn build
 yarn npm publish "${publish_args[@]}"
+
+report_status published "${pkg_name}@${pkg_version}"

--- a/.github/scripts/validate-inputs.sh
+++ b/.github/scripts/validate-inputs.sh
@@ -1,11 +1,50 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+BATCH_SIZE="${BATCH_SIZE:-5}"
+if ! [[ "$BATCH_SIZE" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::BATCH_SIZE must be a positive integer, got '$BATCH_SIZE'"
+  exit 1
+fi
+
 all_languages=(dotnet java python typescript)
 if [ "$LANGUAGE_TO_PUBLISH" = "all" ]; then
   languages=("${all_languages[@]}")
 else
   languages=("$LANGUAGE_TO_PUBLISH")
+fi
+
+API_INCLUDE_LIST="${API_INCLUDE_LIST:-}"
+if [ -z "${API_INCLUDE_LIST//[[:space:]]/}" ]; then
+  echo "No apiIncludeList given - discovering all APIs for: ${languages[*]}"
+
+  discovered=()
+  for lang in "${languages[@]}"; do
+    if [ ! -d "code/${lang}" ]; then
+      echo "::error::Language folder 'code/${lang}' does not exist"
+      exit 1
+    fi
+    for apidir in "code/${lang}"/*/; do
+      [ -d "$apidir" ] || continue
+      api_name="$(basename "$apidir")"
+      # Only APIs that actually have at least one version folder.
+      for verdir in "$apidir"v*/; do
+        [ -d "$verdir" ] || continue
+        discovered+=("$api_name")
+        break
+      done
+    done
+  done
+
+  if [ "${#discovered[@]}" -eq 0 ]; then
+    echo "::error::No APIs discovered under code/ for: ${languages[*]}"
+    exit 1
+  fi
+
+  # Dedupe across languages, then rejoin into the parser's expected format.
+  mapfile -t discovered < <(printf '%s\n' "${discovered[@]}" | sort -u)
+  API_INCLUDE_LIST="$(IFS=,; echo "${discovered[*]}")"
+  echo "Discovered ${#discovered[@]} API(s) to publish."
 fi
 
 declare -A paths
@@ -72,9 +111,43 @@ if [ "$error" -ne 0 ]; then
   exit 1
 fi
 
+readonly MATRIX_LIMIT=256
+
 for lang in "${all_languages[@]}"; do
-  json=$(printf '%s\n' "${paths[$lang]}" | sed '/^$/d' | sort -u | jq -R . | jq -sc .)
-  echo "${lang}_paths=${json}" >> "$GITHUB_OUTPUT"
+  path_list=$(printf '%s\n' "${paths[$lang]}" | sed '/^$/d' | sort -u | jq -R . | jq -sc .)
+  n_paths=$(jq -r 'length' <<< "$path_list")
+
+  # One job per package unless doing so would blow the matrix limit.
+  if [ "$n_paths" -le "$MATRIX_LIMIT" ]; then
+    effective_size=1
+  else
+    effective_size="$BATCH_SIZE"
+    echo "::notice::${lang}: ${n_paths} packages exceeds the ${MATRIX_LIMIT}-job matrix limit; batching ${effective_size} per job."
+  fi
+
+  batches=$(jq -c --argjson n "$effective_size" '
+      [range(0; length; $n) as $i | .[$i:$i+$n]]
+      | length as $total
+      | to_entries
+      | map({
+          id: "\(.key + 1)/\($total)",
+          count: (.value | length),
+          paths: (.value | join(" ")),
+          name: (if (.value | length) == 1
+                 then .value[0]
+                 else "batch \(.key + 1)/\($total) (\(.value | length) pkgs)"
+                 end)
+        })
+    ' <<< "$path_list")
+
+  n_batches=$(jq -r 'length' <<< "$batches")
+  if [ "$n_batches" -gt "$MATRIX_LIMIT" ]; then
+    min_size=$(( (n_paths + MATRIX_LIMIT - 1) / MATRIX_LIMIT ))
+    echo "::error::${lang}: ${n_paths} packages at BATCH_SIZE=${BATCH_SIZE} still yields ${n_batches} jobs, over the ${MATRIX_LIMIT} matrix limit. Raise BATCH_SIZE to at least ${min_size} or narrow apiIncludeList."
+    exit 1
+  fi
+
+  echo "${lang}_batches=${batches}" >> "$GITHUB_OUTPUT"
 done
 
 echo "All entries in apiIncludeList validated successfully."

--- a/.github/scripts/validate-inputs.sh
+++ b/.github/scripts/validate-inputs.sh
@@ -7,6 +7,17 @@ if ! [[ "$BATCH_SIZE" =~ ^[1-9][0-9]*$ ]]; then
   exit 1
 fi
 
+MATRIX_LIMIT="${MATRIX_LIMIT:-256}"
+if ! [[ "$MATRIX_LIMIT" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::MATRIX_LIMIT must be a positive integer, got '$MATRIX_LIMIT'"
+  exit 1
+fi
+if [ "$MATRIX_LIMIT" -gt 256 ]; then
+  echo "::error::MATRIX_LIMIT cannot exceed 256, the GitHub Actions matrix cap, got '$MATRIX_LIMIT'"
+  exit 1
+fi
+readonly MATRIX_LIMIT
+
 all_languages=(dotnet java python typescript)
 if [ "$LANGUAGE_TO_PUBLISH" = "all" ]; then
   languages=("${all_languages[@]}")
@@ -110,8 +121,6 @@ if [ "$error" -ne 0 ]; then
   echo "::error::One or more entries in apiIncludeList are invalid. See errors above."
   exit 1
 fi
-
-readonly MATRIX_LIMIT=256
 
 for lang in "${all_languages[@]}"; do
   path_list=$(printf '%s\n' "${paths[$lang]}" | sed '/^$/d' | sort -u | jq -R . | jq -sc .)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       apiIncludeList:
-        description: 'Limit publishing to this list of API(s) and optional versions, uses the `normalizedName` like "PA Engine API" -> "PAEngine". Example: PAEngine:1,SPAREngine:3'
-        required: true
+        description: 'Limit publishing to this list of API(s) and optional versions, uses the `normalizedName` like "PA Engine API" -> "PAEngine". Example: PAEngine:1,SPAREngine:3. Leave empty to publish every API in the repo.'
+        required: false
+        default: ""
       languageToPublish:
         description: "Language to publish"
         required: true
@@ -22,6 +23,11 @@ on:
         type: boolean
         default: true
 
+env:
+  # Packages per matrix job. Only applies when a language has more than 256
+  # packages to publish; below that each package gets its own job.
+  BATCH_SIZE: 5
+
 jobs:
   validate-inputs:
     runs-on: ubuntu-latest
@@ -30,10 +36,10 @@ jobs:
       contents: read
 
     outputs:
-      dotnet_paths: ${{ steps.validate.outputs.dotnet_paths }}
-      java_paths: ${{ steps.validate.outputs.java_paths }}
-      python_paths: ${{ steps.validate.outputs.python_paths }}
-      typescript_paths: ${{ steps.validate.outputs.typescript_paths }}
+      dotnet_batches: ${{ steps.validate.outputs.dotnet_batches }}
+      java_batches: ${{ steps.validate.outputs.java_batches }}
+      python_batches: ${{ steps.validate.outputs.python_batches }}
+      typescript_batches: ${{ steps.validate.outputs.typescript_batches }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -46,6 +52,7 @@ jobs:
         run: bash "$GITHUB_WORKSPACE/.github/scripts/validate-inputs.sh"
 
   publish-typescript:
+    name: publish-typescript (${{ matrix.batch.name }})
     needs: validate-inputs
     runs-on: ubuntu-latest
 
@@ -53,11 +60,11 @@ jobs:
       id-token: write # Required for OIDC
       contents: read
 
-    if: ${{ (github.event.inputs.languageToPublish == 'all' || github.event.inputs.languageToPublish == 'typescript') && needs.validate-inputs.outputs.typescript_paths != '[]' }}
+    if: ${{ (github.event.inputs.languageToPublish == 'all' || github.event.inputs.languageToPublish == 'typescript') && needs.validate-inputs.outputs.typescript_batches != '[]' }}
     strategy:
       fail-fast: false
       matrix:
-        pkg_path: ${{ fromJSON(needs.validate-inputs.outputs.typescript_paths) }}
+        batch: ${{ fromJSON(needs.validate-inputs.outputs.typescript_batches) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -67,9 +74,11 @@ jobs:
         with:
           node-version: "24"
 
-      - name: Publish package
-        working-directory: ${{ matrix.pkg_path }}
+      - name: Publish packages
         env:
+          LANGUAGE: typescript
+          BATCH_ID: ${{ matrix.batch.id }}
+          PKG_PATHS: ${{ matrix.batch.paths }}
           DRY_RUN: ${{ github.event.inputs.dryRun }}
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
-        run: bash "$GITHUB_WORKSPACE/.github/scripts/publish-typescript.sh"
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/publish-batch.sh"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,10 +22,14 @@ on:
         required: false
         type: boolean
         default: true
+      matrixLimit:
+        description: "Max matrix jobs per language before packages are grouped into batches. 256 is the GitHub cap; lower it to exercise batching."
+        required: false
+        default: "256"
 
 env:
-  # Packages per matrix job. Only applies when a language has more than 256
-  # packages to publish; below that each package gets its own job.
+  # Packages per matrix job. Only applies once a language exceeds matrixLimit
+  # packages; below that each package gets its own job.
   BATCH_SIZE: 5
 
 jobs:
@@ -49,6 +53,7 @@ jobs:
         env:
           API_INCLUDE_LIST: ${{ github.event.inputs.apiIncludeList }}
           LANGUAGE_TO_PUBLISH: ${{ github.event.inputs.languageToPublish }}
+          MATRIX_LIMIT: ${{ github.event.inputs.matrixLimit }}
         run: bash "$GITHUB_WORKSPACE/.github/scripts/validate-inputs.sh"
 
   publish-typescript:


### PR DESCRIPTION
## Why

`publish.yml` fans out one matrix job per package path, and GitHub Actions caps a matrix at **256 jobs per workflow run** — a hard limit that support cannot raise. With 134 API directories per language and 163 version directories today, a broad publish is close enough to that ceiling that it will start failing to launch as the catalogue grows.

This PR adds a batching escape hatch and, separately, makes it possible to publish everything without typing out 134 API names.

## What changed

| File | Change |
| --- | --- |
| `.github/scripts/validate-inputs.sh` | Discovers APIs when `apiIncludeList` is empty; emits `<lang>_batches` instead of `<lang>_paths` |
| `.github/scripts/publish-batch.sh` | **New** — loops a batch, `cd`s per package, calls the language publish script, accumulates failures |
| `.github/scripts/publish-typescript.sh` | Logs `name@version` before publishing |
| `.github/workflows/publish.yml` | `apiIncludeList` now optional; `BATCH_SIZE` env; matrix over batch objects |

### Batching is conditional

**At ≤256 paths, batch size is 1** — one job per package, exactly as today, including per-package job names and log isolation. `BATCH_SIZE` (default 5) only applies once a language exceeds the limit, raising the ceiling to 1280 packages. At the current 163 paths per language, nothing about a normal run changes.

If even `BATCH_SIZE` is too small, the script fails early with the minimum workable value rather than letting GitHub reject the matrix opaquely.

### `apiIncludeList` is now optional

`required: false`, `default: ""`. When empty, every `code/<lang>/<Api>/v<N>` directory for the selected language(s) is discovered from the repo tree. Discovery emits the same comma-separated format the existing parser already consumes, so the validation loop is untouched — discovered names flow through the same existence checks.

### Failure handling

A failing package no longer aborts its batch. The runner publishes everything else, writes a per-package result table to the job summary, and exits non-zero at the end listing what failed.

## Verification

Run locally against the real repo tree:

- **No regression** — `PAEngine,Publisher` yields 4 batches of `count: 1`; the path union is byte-identical to the pre-change `typescript_paths`. Unselected languages still emit `[]`, so the existing `!= '[]'` job guards keep working.
- **Discovery** — empty input finds 134 APIs → 163 paths, matching `ls -d code/typescript/*/v*/ | wc -l` exactly; same match across all four languages under `languageToPublish: all`. Whitespace-only and unset input both take the discovery branch without tripping `set -u`.
- **Threshold** — with `MATRIX_LIMIT` temporarily lowered: at/below the limit, no notice and one package per job; above it, batching engages with no paths lost. The "still too small" error suggested `BATCH_SIZE=3`, which then produced exactly 3 jobs.
- **Failure mode** — with a package failing mid-batch, the *subsequent* package still published, the summary marked one failed, and the job exited 1 naming it.
- **Guards** — invalid `BATCH_SIZE` (`0`, `abc`, `-1`, `3x`) rejected even on small runs where the value goes unused; missing publish script and empty `PKG_PATHS` both error cleanly.
- `bash -n` clean on all three scripts; workflow parses as valid YAML.

Not yet run: an end-to-end `workflow_dispatch` with `dryRun: true`, and `shellcheck` (not installed locally).

## Notes for review

- Batching does not engage at the current catalogue size — that path is covered only by the lowered-limit tests above, not by a real run.
- `publish-batch.sh` is language-generic (`publish-${LANGUAGE}.sh`), so it will serve dotnet/java/python when those jobs are added; `validate-inputs.sh` already emits batches for all four.
- `working-directory` moved out of the workflow: the runner `cd`s per package in a subshell, preserving each publish script's contract of running with cwd = package dir.
